### PR TITLE
移除冗余的本地json读取，改用mirai-console原生的config类, 支持回复自定义内容当图灵服务不可用

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     val kotlinVersion = "1.5.30"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
-    id("net.mamoe.mirai-console") version "2.8.2"
+    id("net.mamoe.mirai-console") version "2.9.2"
 }
 
 group = "tech.eritquearcus"

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -17,13 +17,6 @@
  */
 package tech.eritquearcus.tuling
 
-data class Config(
-    val apikey: String,
-    val gkeyWord: List<String>,
-    val fkeyWord: List<String>,
-    val debug: Boolean?
-)
-
 data class TulingRequest(
     val perception: Perception,
     val reqType: Int,

--- a/src/main/kotlin/TuringConfig.kt
+++ b/src/main/kotlin/TuringConfig.kt
@@ -1,0 +1,22 @@
+package tech.eritquearcus.tuling
+
+import net.mamoe.mirai.console.data.AutoSavePluginConfig
+import net.mamoe.mirai.console.data.ValueDescription
+import net.mamoe.mirai.console.data.value
+
+object TuringConfig:AutoSavePluginConfig("config") {
+    @ValueDescription("图灵机器人密钥")
+    val apikey:String by value()
+
+    @ValueDescription("唤起关键词（群组）")
+    val groupKeyword:List<String> by value()
+
+    @ValueDescription("唤起关键词（私聊）")
+    val friendKeyword:List<String> by value()
+
+    @ValueDescription("是否输出debug信息")
+    val debug:Boolean by value(false)
+
+    @ValueDescription("请求次数超限后的自定义回复")
+    val overLimitReply:List<String> by value()
+}


### PR DESCRIPTION
- 将本地config.json读取修改为使用mirai-console自带的AutoSavePluginConfig工具
- 增加了当api达到使用次数后用户可以自定义回复语的功能